### PR TITLE
Fix example accessory config (rename to Onkyo-tv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example accessory config (needs to be added to the homebridge config.json):
  ```
 "accessories": [
 	{
-		"accessory": "Onkyo",
+		"accessory": "Onkyo-tv",
 		"name": "Stereo",
 		"ip_address": "10.0.1.23",
 		"model" : "TX-NR609",


### PR DESCRIPTION
[2019-2-11 19:56:12] Loaded plugin: homebridge-onkyo
[2019-2-11 19:56:12] Registering accessory 'homebridge-onkyo-tv.Onkyo-tv'